### PR TITLE
Setting output schema in all transform plugins.

### DIFF
--- a/nlp-plugins/src/main/java/io/cdap/google/plugins/AnalyzeEntitiesTransform.java
+++ b/nlp-plugins/src/main/java/io/cdap/google/plugins/AnalyzeEntitiesTransform.java
@@ -133,6 +133,10 @@ public class AnalyzeEntitiesTransform extends NLPTransform {
     return builder.build();
   }
 
+  protected Schema getOutputSchema() {
+    return SCHEMA;
+  }
+
   protected NLPMethod getMethod() {
     return NLPMethod.ANALYZE_ENTITIES;
   }

--- a/nlp-plugins/src/main/java/io/cdap/google/plugins/AnalyzeEntitySentimentTransform.java
+++ b/nlp-plugins/src/main/java/io/cdap/google/plugins/AnalyzeEntitySentimentTransform.java
@@ -117,6 +117,10 @@ public class AnalyzeEntitySentimentTransform extends NLPTransform {
     return builder.build();
   }
 
+  protected Schema getOutputSchema() {
+    return SCHEMA;
+  }
+
   protected NLPMethod getMethod() {
     return NLPMethod.ANALYZE_ENTITY_SENTIMENT;
   }

--- a/nlp-plugins/src/main/java/io/cdap/google/plugins/AnalyzeSentimentTransform.java
+++ b/nlp-plugins/src/main/java/io/cdap/google/plugins/AnalyzeSentimentTransform.java
@@ -101,6 +101,10 @@ public class AnalyzeSentimentTransform extends NLPTransform {
     return builder.build();
   }
 
+  protected Schema getOutputSchema() {
+    return SCHEMA;
+  }
+
   protected NLPMethod getMethod() {
     return NLPMethod.ANALYZE_SENTIMENT;
   }

--- a/nlp-plugins/src/main/java/io/cdap/google/plugins/AnalyzeSyntaxTransform.java
+++ b/nlp-plugins/src/main/java/io/cdap/google/plugins/AnalyzeSyntaxTransform.java
@@ -152,6 +152,10 @@ public class AnalyzeSyntaxTransform extends NLPTransform {
     return builder.build();
   }
 
+  protected Schema getOutputSchema() {
+    return SCHEMA;
+  }
+
   protected NLPMethod getMethod() {
     return NLPMethod.ANALYZE_SYNTAX;
   }

--- a/nlp-plugins/src/main/java/io/cdap/google/plugins/AnotateTextTransform.java
+++ b/nlp-plugins/src/main/java/io/cdap/google/plugins/AnotateTextTransform.java
@@ -197,6 +197,10 @@ public class AnotateTextTransform extends NLPTransform {
     return builder.build();
   }
 
+  protected Schema getOutputSchema() {
+    return SCHEMA;
+  }
+
   protected NLPMethod getMethod() {
     return NLPMethod.ANOTATE_TEXT;
   }

--- a/nlp-plugins/src/main/java/io/cdap/google/plugins/ClassifyContentTransform.java
+++ b/nlp-plugins/src/main/java/io/cdap/google/plugins/ClassifyContentTransform.java
@@ -90,6 +90,10 @@ public class ClassifyContentTransform extends NLPTransform {
     return builder.build();
   }
 
+  protected Schema getOutputSchema() {
+    return SCHEMA;
+  }
+
   protected NLPMethod getMethod() {
     return NLPMethod.CLASSIFY_CONTENT;
   }

--- a/nlp-plugins/src/main/java/io/cdap/google/plugins/NLPTransform.java
+++ b/nlp-plugins/src/main/java/io/cdap/google/plugins/NLPTransform.java
@@ -119,6 +119,8 @@ public abstract class NLPTransform extends Transform<StructuredRecord, Structure
     FailureCollector failureCollector = pipelineConfigurer.getStageConfigurer().getFailureCollector();
     config.validate(failureCollector, inputSchema);
     failureCollector.getOrThrowException();
+
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(getOutputSchema());
   }
 
   @Override
@@ -147,6 +149,7 @@ public abstract class NLPTransform extends Transform<StructuredRecord, Structure
     }
   }
 
+  protected abstract Schema getOutputSchema();
   protected abstract NLPMethod getMethod();
   protected abstract StructuredRecord getRecordFromResponse(MessageOrBuilder message);
 


### PR DESCRIPTION
[bug] The transform plugins don't set their output schema in the `configurePipeline` function. Thus it does not appear in the Data Fusion Studio either.

[fix] Base class sets the output schema using the derived class' schemas. 